### PR TITLE
Adding the option functor

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The following example contains all possible rules.
 tm : Type -- sort declarations
 nat : Type -- preexisting sort declaration, it must not have any constructors
 
-list : Functor -- functor declarations, only "list", "prod", and "cod" are allowed
+list : Functor -- functor declarations, only "list", "prod", "cod" and "option" are allowed
 
 -- declaring some constructors for ty
 arr : ty -> ty -> ty

--- a/share/autosubst/core.v
+++ b/share/autosubst/core.v
@@ -70,6 +70,40 @@ Proof.
   intros H0 H1. destruct p as [a b]. cbn. f_equal; [ apply H0 | apply H1 ].
 Defined.
 
+(** *** Option Instance *)
+
+Definition option_map {A B} (f : A -> B) (p : option A) :
+  option B :=
+match p with
+  | Some a => Some (f a)
+  | None => None
+end.
+
+Definition option_id {A} {f : A -> A} :
+  (forall x, f x = x) -> forall p, option_map f p = p.
+Proof.
+  intros H. destruct p ; cbn.
+  - f_equal. apply H.
+  - reflexivity.
+Defined.
+
+Definition option_ext {A B} {f f' : A -> B} :
+  (forall x, f x = f' x) -> forall p, option_map f p = option_map f' p.
+Proof.
+  intros H. destruct p as [a|] ; cbn.
+  - f_equal. apply H.
+  - reflexivity.
+Defined.
+
+Definition option_comp {A B C} {f : A -> B} {g : B -> C} {h : A -> C}:
+  (forall x, (funcomp  g f) x = h x) ->
+  forall p, option_map g (option_map f p) = option_map h p.
+Proof.
+  intros H. destruct p as [a|]; cbn.
+  - f_equal. apply H.
+  - reflexivity. 
+Defined.
+
 (* a.d. TODO hints outside of sections without explicit locality are deprecated. Is this even used in the first place?  *)
 (* but with 8.13.1 the attribute is forbidden. So what's the correct way to use this? *)
 (* #[ global ] *)

--- a/traced/core.v
+++ b/traced/core.v
@@ -76,6 +76,40 @@ Proof.
   intros H0 H1. destruct p as [a b]. cbn. f_equal; [ apply H0 | apply H1 ].
 Defined.
 
+(** *** Option Instance *)
+
+Definition option_map {A B} (f : A -> B) (p : option A) :
+  option B :=
+match p with
+  | Some a => Some (f a)
+  | None => None
+end.
+
+Definition option_id {A} {f : A -> A} :
+  (forall x, f x = x) -> forall p, option_map f p = p.
+Proof.
+  intros H. destruct p ; cbn.
+  - f_equal. apply H.
+  - reflexivity.
+Defined.
+
+Definition option_ext {A B} {f f' : A -> B} :
+  (forall x, f x = f' x) -> forall p, option_map f p = option_map f' p.
+Proof.
+  intros H. destruct p as [a|] ; cbn.
+  - f_equal. apply H.
+  - reflexivity.
+Defined.
+
+Definition option_comp {A B C} {f : A -> B} {g : B -> C} {h : A -> C}:
+  (forall x, (funcomp  g f) x = h x) ->
+  forall p, option_map g (option_map f p) = option_map h p.
+Proof.
+  intros H. destruct p as [a|]; cbn.
+  - f_equal. apply H.
+  - reflexivity. 
+Defined.
+
 (* a.d. TODO hints outside of sections without explicit locality are deprecated. Is this even used in the first place?  *)
 (* but with 8.13.1 the attribute is forbidden. So what's the correct way to use this? *)
 (* #[ global ] *)


### PR DESCRIPTION
We add the lemmas needed in `core.v` to add `option` to the list of possible functors.