### PR TITLE
Adapt to change of type of VernacFixpoint in Coq PR #19107 

### DIFF
--- a/lib/gallinaGen.ml
+++ b/lib/gallinaGen.ml
@@ -76,12 +76,12 @@ let fixpointBody_ name binders rtype body struc =
   let open Vernacexpr in
   let feg = { fname=lident_ name;
               univs=None;
-              rec_order=Some (CAst.make (Constrexpr.CStructRec (lident_ struc)));
               binders;
               rtype;
               body_def=Some body;
               notations=[] } in
-  feg
+  let rec_order = Some (CAst.make (Constrexpr.CStructRec (lident_ struc))) in
+  rec_order, feg
 
 
 let match_ cexpr ?rtype bexprs =

--- a/lib/vernacGen.ml
+++ b/lib/vernacGen.ml
@@ -51,10 +51,10 @@ let fixpoint_ ~is_rec fexprs =
   | [] -> failwith "fixpoint called without fixpoint bodies"
   | fexprs_nempty ->
     if is_rec
-    then unit_of_vernacs [ VernacSynPure (VernacFixpoint (NoDischarge, fexprs)) ]
+    then unit_of_vernacs [ VernacSynPure (VernacFixpoint (NoDischarge, List.split fexprs)) ]
     (* if the fixpoint is declared non-recursive we try to turn it into a definition *)
     else match fexprs_nempty with
-      | [{ fname={ v=fname; _ }; binders; rtype; body_def=Some body; _}] ->
+      | [_, { fname={ v=fname; _ }; binders; rtype; body_def=Some body; _}] ->
         definition_ (Names.Id.to_string fname) binders ~rtype body
       | [fexpr] -> failwith "Malformed fixpoint body"
       | _ -> failwith "A non recursive fixpoint degenerates to a definition so it should only have one body"


### PR DESCRIPTION
PR coq/coq#19107 unifies the structure of the ast regarding fixpoints and cofixpoints. This PR adapts to the change. It should be merged synchronously. Thanks in advance.