### PR TITLE
Adapt to Coq PR #19404: an algebra of types for the instances of notation variables

### DIFF
--- a/lib/gallinaGen.ml
+++ b/lib/gallinaGen.ml
@@ -34,7 +34,7 @@ let eq_ t1 t2 =
   CAst.make (Constrexpr.CNotation
                (Some (Constrexpr.LastLonelyNotation),
                 (Constrexpr.InConstrEntry, "_ = _"),
-                ([ t1; t2 ], [], [], [])))
+                [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2) ]))
 
 let lname_ s = CAst.make (Names.Name (name_id_ s))
 let name_decl_ s = lname_ s, None
@@ -54,7 +54,7 @@ let arr_ tys tyend =
       CAst.make (Constrexpr.CNotation
                    (Some (Constrexpr.LastLonelyNotation),
                     (Constrexpr.InConstrEntry, "_ -> _"),
-                    ([ t1; t2 ], [], [], []))))
+                    [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2) ])))
     tys tyend
 
 let arr1_ ty1 ty2 = arr_ [ty1] ty2

--- a/lib/gallinaGen.ml
+++ b/lib/gallinaGen.ml
@@ -33,7 +33,7 @@ let app_ref ?(expl=false) s t =
 let eq_ t1 t2 =
   CAst.make (Constrexpr.CNotation
                (Some (Constrexpr.LastLonelyNotation),
-                (Constrexpr.InConstrEntry, "_ = _"),
+                {ntn_entry = InConstrEntry; ntn_key = "_ = _"},
                 [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2) ]))
 
 let lname_ s = CAst.make (Names.Name (name_id_ s))
@@ -53,7 +53,7 @@ let arr_ tys tyend =
   List.fold_right (fun t1 t2 ->
       CAst.make (Constrexpr.CNotation
                    (Some (Constrexpr.LastLonelyNotation),
-                    (Constrexpr.InConstrEntry, "_ -> _"),
+                    {ntn_entry = InConstrEntry; ntn_key = "_ -> _"},
                     [NtnTypeArg (NtnTypeArgConstr t1); NtnTypeArg (NtnTypeArgConstr t2) ])))
     tys tyend
 


### PR DESCRIPTION
This PR is in preparation of coq/coq#19404 which introduces an algebra of types for the instances of notation variables.

To be merged synchronously.