### PR TITLE
Adapt to Coq PR #19301 which unifies the syntax of Theorem, Definition and Fixpoint

### DIFF
--- a/lib/gallinaGen.ml
+++ b/lib/gallinaGen.ml
@@ -66,10 +66,15 @@ let inductiveBody_ iname iparams ?rtype iconstructors =
     rtype, (* type I guess *)
     Vernacexpr.Constructors iconstructors), [])
 
-let definition_expr_ dbinders ?rtype dbody =
+let definition_expr_ dname dbinders ?rtype dbody =
+  let dname = lident_ dname in
   let open Vernacexpr in
-  DefineBody (dbinders, None, dbody, rtype)
+  { fname=dname; univs=None; binders=dbinders; body_def=DefineBody (None, dbody, rtype); notations=[] }
 
+let theorem_expr_ dname dbinders rtype =
+  let dname = lident_ dname in
+  let open Vernacexpr in
+  { fname=dname; univs=None; binders=dbinders; body_def=ProveBody rtype; notations=[] }
 
 type fixpoint_expr = Vernacexpr.fixpoint_expr
 let fixpointBody_ name binders rtype body struc =
@@ -77,8 +82,7 @@ let fixpointBody_ name binders rtype body struc =
   let feg = { fname=lident_ name;
               univs=None;
               binders;
-              rtype;
-              body_def=Some body;
+              body_def=DefineBody (None, body, Some rtype);
               notations=[] } in
   let rec_order = Some (CAst.make (Constrexpr.CStructRec (lident_ struc))) in
   rec_order, feg

--- a/lib/gallinaGen.mli
+++ b/lib/gallinaGen.mli
@@ -43,7 +43,8 @@ type inductive_body = Vernacexpr.inductive_expr * Vernacexpr.notation_declaratio
 val constructor_ : identifier -> constr_expr -> Vernacexpr.constructor_expr
 val inductiveBody_ : identifier -> binder_expr list -> ?rtype:constr_expr -> constructor_expr list -> inductive_body
 
-val definition_expr_ : binder_expr list -> ?rtype:constr_expr -> constr_expr -> Vernacexpr.definition_expr
+val definition_expr_ : identifier -> binder_expr list -> ?rtype:constr_expr -> constr_expr -> Vernacexpr.definition_expr
+val theorem_expr_ : identifier -> binder_expr list -> constr_expr -> Vernacexpr.definition_expr
 
 type fixpoint_expr = Vernacexpr.fixpoint_expr
 val fixpointBody_ : identifier -> binder_expr list -> constr_expr -> constr_expr -> identifier -> fixpoint_expr


### PR DESCRIPTION
The change is rather straightforward.

In particular, I guess that it is not anymore necessary to retrograde a non-recursive fixpoint to a definition. If there is no `{struct ...}` in a unary declaration, this will be automatically the case.

To be merged synchronously with coq/coq#19301 when the latter is ready.