### PR TITLE
Coq 8.20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
         opam_file:
           - 'coq-autosubst-ocaml.opam'
         image:
-          - 'coqorg/coq:8.19-rc1-ocaml-4.14.1-flambda' 
+          - 'coqorg/coq:dev-ocaml-4.14.1-flambda'
       fail-fast: false  # don't stop jobs if one fails
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ First, install opam following the [directions for your operating system](https:/
 It is best practice to create a new opam switch to not cause conflicts with any of your other installed packages.
 We will also need to add the Coq repository and then we can install the `coq-autosubst-ocaml` package.
 ```bash
-$ opam switch create autosubst-ocaml ocaml-base-compiler.4.11.1
+$ opam switch create autosubst-master --packages="ocaml-variants.4.14.1+options,ocaml-option-flambda"
 $ eval $(opam env)
-$ opam repo add coq-released https://coq.inria.fr/opam/released
+$ opam repo add coq-core-dev https://coq.inria.fr/opam/core-dev
 $ opam install coq-autosubst-ocaml
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - Maintainer:
   - Yannick Forster ([**@yforster**](https://github.com/yforster))
 - License: [MIT License](LICENSE)
-- Compatible Coq versions: 8.19.0
+- Compatible Coq versions: 8.20.0
 - Related publication(s):
   - Adrian Dapprich's [bachelor thesis](https://www.ps.uni-saarland.de/~dapprich/bachelor.php) (Advisor: Andrej Dudenhefner, Supervisor: Gert Smolka)
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This is an OCaml reimplementation of the [Autosubst 2 code generator](https://gi
 If you ever were in the situation of looking at metatheorems of languages modelled in Coq (e.g. progress and preservation of lambda calculi) and were bothered by the tediousness of formalizing substitution of de Bruijn indices again, this tool might be for you.
 Autosubst is a tool that allows you to quickly generate boilerplate code to handle substitutions in languages with binders.
 
-The output is Coq source code that contains 
+The output is Coq source code that contains
 1. an implementation of the language via (mutual) inductive types and de Bruijn indices for variables,
 2. definitions for capture avoiding substitution and renaming on de Bruijn indices,
 3. lemmas about the behavior and interaction of renaming and substitution,
@@ -108,7 +108,7 @@ s[t · id][σ] = s[⇑ σ][t[σ] · id]
 For more examples and an extended explanation as well as an explanation of the notation we refer to Adrian's bachelor thesis or Stark's doctoral dissertation linked above.
 
 ## Setup
-### Opam 
+### Opam
 First, install opam following the [directions for your operating system](https://opam.ocaml.org/doc/Install.html).
 
 It is best practice to create a new opam switch to not cause conflicts with any of your other installed packages.
@@ -160,14 +160,23 @@ const : nat -> tm
 ```
 
 ## Development
+
 ### Dev Dependencies
+
 Some dependencies for developing in emacs.
 ```bash
 $ opam install merlin utop ocp-indent ocamlformat
 $ opam user-setup install
 ```
 
+You also need the dependencies listed in the opam package, you can get them
+with
+```bash
+opam install --deps-only .
+```
+
 ### Build & Run
+
 Create the switch, install the dependencies, and then:
 ```bash
 $ dune build

--- a/coq-autosubst-ocaml.opam
+++ b/coq-autosubst-ocaml.opam
@@ -11,12 +11,12 @@ description: """
 homepage: "https://github.com/uds-psl/autosubst-ocaml"
 bug-reports: "https://github.com/uds-psl/autosubst-ocaml/issues"
 maintainer: "Yannick Forster yannick.forster@inria.fr"
-authors: [ "Adrian Dapprich s8addapp@stud.uni-saarland.de" ]
+authors: [ "Adrian Dapprich" ]
 license: "MIT"
 
 depends: [
   "ocaml" { >= "4.09" & < "4.15" }
-  "coq" { >= "8.19" & < "8.20" }
+  "coq" { = "dev" }
   "angstrom" { >= "0.15.0" }
   "dune" { >= "2.5" }
   "ocamlgraph" { >= "2.0.0" }

--- a/coq-autosubst-ocaml.opam
+++ b/coq-autosubst-ocaml.opam
@@ -16,7 +16,7 @@ license: "MIT"
 
 depends: [
   "ocaml" { >= "4.09" & < "4.15" }
-  "coq" { = "dev" }
+  "coq" { >= "8.20" & < "8.21" }
   "angstrom" { >= "0.15.0" }
   "dune" { >= "2.5" }
   "ocamlgraph" { >= "2.0.0" }

--- a/lib/gallinaGen.ml
+++ b/lib/gallinaGen.ml
@@ -16,8 +16,8 @@ let lident_ s = CAst.make (name_id_ s)
 let name_ s = Names.Name.mk_name (name_id_ s)
 
 let underscore_ = CAst.make Constrexpr.(CHole None)
-let prop_ = CAst.make Constrexpr.(CSort (Glob_term.UNamed (None,[CProp, 0])))
-let type_ = CAst.make Constrexpr.(CSort (Glob_term.UAnonymous { rigid = UnivRigid }))
+let prop_ = CAst.make Constrexpr.(CSort Constrexpr_ops.expr_Prop_sort)
+let type_ = CAst.make Constrexpr.(CSort Constrexpr_ops.expr_Type_sort)
 
 let app_ f xs =
   Constrexpr_ops.mkAppC (f, xs)

--- a/lib/gallinaGen.ml
+++ b/lib/gallinaGen.ml
@@ -92,7 +92,7 @@ let binder_ ?(implicit=false) ?btype bnames =
   let open Constrexpr in
   let bk = Default (if implicit then Glob_term.MaxImplicit else Glob_term.Explicit) in
   let btype = Option.default (CAst.make @@ CHole None) btype in
-  CLocalAssum (List.map lname_ bnames, bk, btype)
+  CLocalAssum (List.map lname_ bnames, None, bk, btype)
 
 let binder1_ ?implicit ?btype bname =
   binder_ ?implicit ?btype [bname]


### PR DESCRIPTION
This is just a selection of the right prefix of the master branch that builds with Coq 8.20, plus an update of the README and opam package.

To be closed and integrated as its own `coq-8.20` branch.