### PR TITLE
Always add sort as a vertex to the graph in case it is a simple enum

### DIFF
--- a/lib/sigAnalyzer.ml
+++ b/lib/sigAnalyzer.ml
@@ -24,7 +24,7 @@ let build_graph spec =
   let specl = AL.to_list spec in
   List.fold_left (fun g (t, cs) ->
       let args = List.(concat (map L.getArgs cs)) in
-      List.fold_left (fun g arg -> G.add_edge g t arg) g args)
+      G.add_vertex (List.fold_left (fun g arg -> G.add_edge g t arg) g args) t)
     G.empty specl
 
 (** A sort x needs a binder if it is bound in some sort y and also occurs in y.


### PR DESCRIPTION
This patch should fix the issue mentioned in https://github.com/uds-psl/autosubst-ocaml/issues/28

The culprit is the `build_graph` function, which won't add enum sorts as vertices to the graph through the `add_edge` function as their constructors don't have any arguments (and thus have no edges).

When `G.succ` in `build_signature` gets called later, an exception would be thrown because the enum vertex is never inserted.